### PR TITLE
Example grendel.toml file fixes and added comments.

### DIFF
--- a/grendel.toml.sample
+++ b/grendel.toml.sample
@@ -20,24 +20,32 @@ listen = "0.0.0.0:80"
 
 # HTTP protocol used for provisioning (http or https)
 scheme = "http"
+#
+# For https also set the SSL Certificate:
+#
+#scheme = "https"
+#
+# hostname for grendel, should also be the hostname for the SSL certificate
+#hostname = "my.host.name"
+#
+# Path to ssl cert (.crt file)
+#cert = "/path/to/cert/file/hostname.crt"
+#
+# Path to ssl key (.key file)
+#key = "/path/to/cert/file/hostname.key"
+#
 
 # TTL in seconds for provision tokens. Defaults to 1 hour
 token_ttl = 3600
 
 # Can generate secret with `openssl rand -hex 32`
-secret = ""
+#secret = "_provisioning_secret_here_"
 
 # Hashed root password used in kickstart template
 root_password = ""
 
 # Default OS image name
 default_image = ""
-
-# Path to ssl cert 
-cert = ""
-
-# Path to ssl key 
-key = ""
 
 # Path to repo directory
 repo_dir = ""
@@ -69,7 +77,7 @@ mtu = 1500
 router_octet4 = 0
 
 # Hard code a static router. Not set by default.
-router = ""
+#router = ""
 
 # Default netmask example: 8, 16, 24, etc.
 netmask = 24
@@ -103,7 +111,7 @@ listen = "0.0.0.0:4011"
 #------------------------------------------------------------------------------
 [api]
 # Can generate secret with `openssl rand -hex 32`
-secret = ""
+#secret = "_api_secret_here_"
 
 # Path to unix socket
 socket_path = "grendel-api.socket"

--- a/grendel.toml.sample
+++ b/grendel.toml.sample
@@ -16,12 +16,14 @@ dbpath = ":memory:"
 # HTTP Provision Server
 #------------------------------------------------------------------------------
 [provision]
-listen = "0.0.0.0:80"
 
-# HTTP protocol used for provisioning (http or https)
+# For provisioning with http
+listen = "0.0.0.0:80"
 scheme = "http"
+
+# For provisioning with https
 #
-# For https also set the SSL Certificate:
+#listen = "0.0.0.0:443"
 #
 #scheme = "https"
 #


### PR DESCRIPTION
If the provisioning secret is an empty string e.g.

secret = ""

This results in the following error during netboot:

ERROR PXE: Failed to generated signed firmware token: bad key length

If a static route is defined as as empty string e.g.

route = ""

Then grendel fails to start with the error:

FATAL CLI: Invalid router ip address:

Moved the SSL related options together, adding notes on the "hostname" option

Tony