### PR TITLE
Fix nil check on routerIP

### DIFF
--- a/cmd/serve/dhcp.go
+++ b/cmd/serve/dhcp.go
@@ -147,7 +147,7 @@ func serveDHCP(t *tomb.Tomb) error {
 
 	if viper.IsSet("dhcp.router") {
 		routerIP := net.ParseIP(viper.GetString("dhcp.router"))
-		if routerIP != nil || routerIP.To4() == nil {
+		if routerIP == nil || routerIP.To4() == nil {
 			return fmt.Errorf("Invalid router ip address: %s", viper.GetString("dhcp.router"))
 		}
 


### PR DESCRIPTION
When the dhcp.router configuration option is specified the nil check will cause it to always return an error as invalid. Flip the logic to correctly check if its nil or not.