### PR TITLE
Add support for Dell Zero-touch deployment

### DIFF
--- a/cmd/discover/dhcp.go
+++ b/cmd/discover/dhcp.go
@@ -158,6 +158,11 @@ func snoopDHCP(req *dhcpv4.DHCPv4) {
 	if req.Options.Has(dhcpv4.OptionUserClassInformation) {
 		userClass = string(req.Options.Get(dhcpv4.OptionUserClassInformation))
 	}
+	classID := req.ClassIdentifier()
+	clientID := ""
+	if req.Options.Has(dhcpv4.OptionClientIdentifier) {
+		clientID = dhcpv4.GetString(dhcpv4.OptionClientIdentifier, req.Options)
+	}
 	archType := ""
 	if req.Options.Has(dhcpv4.OptionClientSystemArchitectureType) {
 		archType = string(req.Options.Get(dhcpv4.OptionClientSystemArchitectureType))
@@ -174,6 +179,8 @@ func snoopDHCP(req *dhcpv4.DHCPv4) {
 		"userClass": userClass,
 		"hostname":  hostName,
 		"arch":      archType,
+		"clientID":  clientID,
+		"classID":   classID,
 	}).Debug()
 }
 

--- a/cmd/serve/tftp.go
+++ b/cmd/serve/tftp.go
@@ -54,7 +54,7 @@ func serveTFTP(t *tomb.Tomb) error {
 		return err
 	}
 
-	tftpServer, err := tftp.NewServer(tftpListen)
+	tftpServer, err := tftp.NewServer(DB, tftpListen)
 	if err != nil {
 		return err
 	}

--- a/dhcp/server.go
+++ b/dhcp/server.go
@@ -165,7 +165,7 @@ func (s *Server) mainHandler4(peer *net.UDPAddr, req *dhcpv4.DHCPv4, oob *ipv4.C
 		}
 
 		if !s.ProxyOnly {
-			err := s.staticHandler4(host, req, resp)
+			err := s.staticHandler4(host, serverIP, req, resp)
 			if err != nil {
 				log.Errorf("Failed to add client ip to DHCP DISCOVER: %s", err)
 				return

--- a/model/host.go
+++ b/model/host.go
@@ -54,10 +54,10 @@ func (h *Host) HasTags(tags ...string) bool {
 		}
 	}
 
-	return true
+	return len(tags) > 0
 }
 
-func (h *Host) HasAnyTag(tags ...string) bool {
+func (h *Host) HasAnyTags(tags ...string) bool {
 	for _, a := range h.Tags {
 		for _, b := range tags {
 			if a == b {

--- a/model/host.go
+++ b/model/host.go
@@ -39,6 +39,36 @@ type Host struct {
 	Tags       []string        `json:"tags"`
 }
 
+func (h *Host) HasTags(tags ...string) bool {
+	for _, a := range tags {
+		found := false
+		for _, b := range h.Tags {
+			if a == b {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (h *Host) HasAnyTag(tags ...string) bool {
+	for _, a := range h.Tags {
+		for _, b := range tags {
+			if a == b {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 func (h *Host) Interface(mac net.HardwareAddr) *NetInterface {
 	for _, nic := range h.Interfaces {
 		if bytes.Compare(nic.MAC, mac) == 0 {

--- a/model/host_test.go
+++ b/model/host_test.go
@@ -1,0 +1,40 @@
+// Copyright 2019 Grendel Authors. All rights reserved.
+//
+// This file is part of Grendel.
+//
+// Grendel is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Grendel is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Grendel. If not, see <https://www.gnu.org/licenses/>.
+
+package model_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/ubccr/grendel/internal/tests"
+	"github.com/ubccr/grendel/model"
+)
+
+func TestHostTags(t *testing.T) {
+	assert := assert.New(t)
+
+	host := tests.HostFactory.MustCreate().(*model.Host)
+	host.Tags = []string{"k11", "switch", "dellztd"}
+
+	assert.True(host.HasTags("k11", "dellztd"))
+	assert.False(host.HasTags("p22", "dellztd"))
+	assert.True(host.HasAnyTags("p22", "dellztd"))
+	assert.False(host.HasAnyTags("p22", "m12"))
+	assert.False(host.HasAnyTags())
+	assert.False(host.HasTags())
+}

--- a/tftp/handler.go
+++ b/tftp/handler.go
@@ -21,17 +21,58 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/pin/tftp"
 	"github.com/ubccr/grendel/model"
 )
 
+func (s *Server) sendFile(fileName string, rf io.ReaderFrom) error {
+	file, err := os.Open(fileName)
+	if err != nil {
+		log.Errorf("Failed to open %s: %s", fileName, err)
+		return err
+	}
+	n, err := rf.ReadFrom(file)
+	if err != nil {
+		log.Errorf("Failed to send %s via tftp: %s", fileName, err)
+		return err
+	}
+
+	log.Infof("Sent %s via tftp: %d bytes sent", fileName, n)
+	return nil
+}
+
+func (s *Server) imageFileHandler(filePath string, rf io.ReaderFrom) error {
+	imageName, fileType := filepath.Split(filePath)
+	bootImage, err := s.DB.LoadBootImage(strings.TrimSuffix(imageName, "/"))
+	if err != nil {
+		log.Errorf("File not found: %s", filePath)
+		return err
+	}
+
+	switch {
+	case fileType == "kernel":
+		return s.sendFile(bootImage.KernelPath, rf)
+	case strings.HasPrefix(fileType, "initrd-"):
+		i, err := strconv.Atoi(fileType[7:])
+		if err != nil || i < 0 || i >= len(bootImage.InitrdPaths) {
+			return fmt.Errorf("no initrd with ID %q", i)
+		}
+		initrd := bootImage.InitrdPaths[i]
+		return s.sendFile(initrd, rf)
+	}
+
+	return fmt.Errorf("File not found: %s", filePath)
+}
+
 func (s *Server) ReadHandler(token string, rf io.ReaderFrom) error {
 	fwtype, err := model.ParseFirmwareToken(token)
 	if err != nil {
-		log.Errorf("failed to parse token: %s", err)
-		return err
+		return s.imageFileHandler(token, rf)
 	}
 
 	log.Infof("Got read request for firmware type: %d", fwtype)

--- a/tftp/server.go
+++ b/tftp/server.go
@@ -23,17 +23,19 @@ import (
 
 	"github.com/pin/tftp"
 	"github.com/ubccr/grendel/logger"
+	"github.com/ubccr/grendel/model"
 )
 
 var log = logger.GetLogger("TFTP")
 
 type Server struct {
 	Address string
+	DB      model.DataStore
 	srv     *tftp.Server
 }
 
-func NewServer(address string) (*Server, error) {
-	s := &Server{Address: address}
+func NewServer(db model.DataStore, address string) (*Server, error) {
+	s := &Server{DB: db, Address: address}
 
 	s.srv = tftp.NewServer(s.ReadHandler, nil)
 	s.srv.SetTimeout(2 * time.Second)


### PR DESCRIPTION
Adds support for sending DHCP options related to auto provisioning dell switches using Zero-touch deployment (ZTD) for use with DellOS10 and the older Bare Metal Provisioning (BMP) for use with FTOS.