### PR TITLE
RHEL 8 Kickstart attempts a HEAD before GET of a liveimg

### DIFF
--- a/provision/handler.go
+++ b/provision/handler.go
@@ -74,6 +74,7 @@ func (h *Handler) SetupRoutes(e *echo.Echo) {
 	boot.GET("ipxe", h.Ipxe)
 	boot.GET("kickstart", h.Kickstart)
 	boot.GET("file/kernel*", h.File)
+	boot.HEAD("file/liveimg", h.File)
 	boot.GET("file/liveimg", h.File)
 	boot.GET("file/rootfs", h.File)
 	boot.GET("file/initrd-*", h.File)


### PR DESCRIPTION
Attempting to kickstart using RHEL 8 (8.6 tested) with a liveimg fails because the installer tries to do a HEAD of the file first (which fails with "unsupported method" causing the install to abort) before downloading the image normally with a GET.